### PR TITLE
Modernize header/hero palette + RDU-specific tagline

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1065,6 +1065,21 @@ iframe {
   border-bottom-color: rgb(148 163 184 / var(--tw-border-opacity));
 }
 
+.border-b-slate-700 {
+  --tw-border-opacity: 1;
+  border-bottom-color: rgb(51 65 85 / var(--tw-border-opacity));
+}
+
+.border-b-red-950 {
+  --tw-border-opacity: 1;
+  border-bottom-color: rgb(69 10 10 / var(--tw-border-opacity));
+}
+
+.border-b-slate-800 {
+  --tw-border-opacity: 1;
+  border-bottom-color: rgb(30 41 59 / var(--tw-border-opacity));
+}
+
 .bg-amber-300 {
   --tw-bg-opacity: 1;
   background-color: rgb(252 211 77 / var(--tw-bg-opacity));
@@ -1098,6 +1113,31 @@ iframe {
 .bg-slate-900 {
   --tw-bg-opacity: 1;
   background-color: rgb(15 23 42 / var(--tw-bg-opacity));
+}
+
+.bg-emerald-500 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(16 185 129 / var(--tw-bg-opacity));
+}
+
+.bg-slate-950 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(2 6 23 / var(--tw-bg-opacity));
+}
+
+.bg-amber-400 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(251 191 36 / var(--tw-bg-opacity));
+}
+
+.bg-red-950 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(69 10 10 / var(--tw-bg-opacity));
+}
+
+.bg-cyan-400 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(34 211 238 / var(--tw-bg-opacity));
 }
 
 .bg-gradient-to-b {
@@ -1158,6 +1198,34 @@ iframe {
   --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
 }
 
+.from-slate-950 {
+  --tw-gradient-from: #020617 var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(2 6 23 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
+.from-red-950 {
+  --tw-gradient-from: #450a0a var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(69 10 10 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
+.from-cyan-800\/70 {
+  --tw-gradient-from: rgb(21 94 117 / 0.7) var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(21 94 117 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
+.via-slate-900 {
+  --tw-gradient-to: rgb(15 23 42 / 0)  var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), #0f172a var(--tw-gradient-via-position), var(--tw-gradient-to);
+}
+
+.via-cyan-950 {
+  --tw-gradient-to: rgb(8 51 68 / 0)  var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), #083344 var(--tw-gradient-via-position), var(--tw-gradient-to);
+}
+
 .to-amber-400 {
   --tw-gradient-to: #fbbf24 var(--tw-gradient-to-position);
 }
@@ -1190,12 +1258,48 @@ iframe {
   --tw-gradient-to: #f4f4f5 var(--tw-gradient-to-position);
 }
 
+.to-red-950 {
+  --tw-gradient-to: #450a0a var(--tw-gradient-to-position);
+}
+
+.to-red-800 {
+  --tw-gradient-to: #991b1b var(--tw-gradient-to-position);
+}
+
+.to-slate-900 {
+  --tw-gradient-to: #0f172a var(--tw-gradient-to-position);
+}
+
+.to-cyan-950 {
+  --tw-gradient-to: #083344 var(--tw-gradient-to-position);
+}
+
+.to-cyan-900 {
+  --tw-gradient-to: #164e63 var(--tw-gradient-to-position);
+}
+
+.to-cyan-950\/70 {
+  --tw-gradient-to: rgb(8 51 68 / 0.7) var(--tw-gradient-to-position);
+}
+
 .fill-slate-50 {
   fill: #f8fafc;
 }
 
 .fill-slate-800 {
   fill: #1e293b;
+}
+
+.fill-white {
+  fill: #fff;
+}
+
+.fill-red-950 {
+  fill: #450a0a;
+}
+
+.fill-slate-950 {
+  fill: #020617;
 }
 
 .p-2 {
@@ -1452,6 +1556,16 @@ iframe {
   color: rgb(39 39 42 / var(--tw-text-opacity));
 }
 
+.text-red-950 {
+  --tw-text-opacity: 1;
+  color: rgb(69 10 10 / var(--tw-text-opacity));
+}
+
+.text-slate-950 {
+  --tw-text-opacity: 1;
+  color: rgb(2 6 23 / var(--tw-text-opacity));
+}
+
 .line-through {
   text-decoration-line: line-through;
 }
@@ -1468,6 +1582,23 @@ iframe {
   --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-md {
+  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-lg {
+  --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-cyan-500\/30 {
+  --tw-shadow-color: rgb(6 182 212 / 0.3);
+  --tw-shadow: var(--tw-shadow-colored);
 }
 
 .drop-shadow-\[1\.5px_1\.5px_1\.2px_rgba\(0\2c 0\2c 0\2c 0\.9\)\] {
@@ -1489,6 +1620,12 @@ iframe {
   transition-duration: 150ms;
 }
 
+.transition-colors {
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
 .duration-1500 {
   transition-duration: 1500ms;
 }
@@ -1505,6 +1642,21 @@ iframe {
 .hover\:bg-slate-400:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(148 163 184 / var(--tw-bg-opacity));
+}
+
+.hover\:bg-emerald-400:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(52 211 153 / var(--tw-bg-opacity));
+}
+
+.hover\:bg-amber-300:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(252 211 77 / var(--tw-bg-opacity));
+}
+
+.hover\:bg-cyan-300:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(103 232 249 / var(--tw-bg-opacity));
 }
 
 .hover\:from-green-500:hover {

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,7 @@
     <meta charset="utf-8" />
     <meta
       name="description"
-      content="BSides RDU - Friday, December 18th 2026 - Security BSides is a community-driven framework for building events for and by cybersecurity community members. The goal is to expand the spectrum of conversation beyond the traditional confines of space and time. It creates opportunities for individuals to both present and participate in an intimate atmosphere that encourages collaboration. It is an intense event with discussions, demos, and interaction from participants. It is where conversations for the next-big-thing are happening. Security is top of mind across the entire sphere of IT and the world beyond. Therefore, more people and organizations are interested in the next new thing in security. BSides is the place where these people come to collaborate, learn and share. With many tech-companies, colleges and universities in Raleigh, Durham, Chapel Hill and surrounding areas, it is also an international center of innovation in the security industry. Security B-Sides Raleigh-Durham (B-Sides RDU) is proud to have had great speaker lineups at our events including keynotes by Dan Kaminsky, Dave Kennedy, Paul Vixie, BenTen, Jay Beale, G.Mark Hardy, and for B-Sides RDU 2017: Cliff Stoll."
+      content="BSides RDU — Friday, December 18th 2026 at the McKimmon Center, NC State. Raleigh-Durham's grassroots security conference, built by and for the region's cybersecurity community. A day of talks, demos, villages, and hands-on hacking where hackers, defenders, and builders from Raleigh, Durham, Chapel Hill and beyond come together to collaborate, learn, and share. BSides RDU is proud to have hosted keynotes by Dan Kaminsky, Dave Kennedy, Paul Vixie, BenTen, Jay Beale, G. Mark Hardy, and Cliff Stoll."
     />
     <meta name="format-detection" content="telephone=no" />
     <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1" />
@@ -22,7 +22,7 @@
     <meta property="og:title" content="BSides RDU | Friday, Dec. 18th, 2026 | Cybersecurity Conference" />
     <meta
       property="og:description"
-      content="Friday, December 18th 2026 - Security BSides is a community-driven framework for building events for and by cybersecurity community members. The goal is to expand the spectrum of conversation beyond the traditional confines of space and time. It creates opportunities for individuals to both present and participate in an intimate atmosphere that encourages collaboration. It is an intense event with discussions, demos, and interaction from participants."
+      content="Friday, December 18th 2026 at the McKimmon Center, NC State — Raleigh-Durham's grassroots security conference, built by and for the region's cybersecurity community. A day of talks, demos, and hands-on hacking where hackers, defenders, and builders come together to collaborate, learn, and share."
     />
     <meta property="og:image" content="https://bsidesrdu.org/img/bsides-logo-og.png" />
     <meta property="og:image:secure_url" content="https://bsidesrdu.org/img/bsides-logo-og.png" />
@@ -55,11 +55,11 @@
             <!-- ANCHOR register buy tickets button #1 -->
             <a
               href="https://www.eventzilla.net/e/bsidesrdu-2026-2138673041"
-              class="mr-2 flex flex-row items-center gap-1 rounded-xl bg-gradient-to-b from-green-600 to-green-300 px-3 py-1 font-semibold italic text-gray-950 hover:from-green-500 hover:to-green-200 hover:text-green-900"
+              class="mr-2 flex flex-row items-center gap-1 rounded-xl bg-cyan-400 px-3 py-1 font-semibold italic text-slate-950 shadow-md shadow-cyan-500/30 transition-colors hover:bg-cyan-300"
             >
               Register or Donate
               <span class="hidden sm:inline">Now</span>
-              <svg class="h-3 w-3 fill-slate-800">
+              <svg class="h-3 w-3 fill-slate-950">
                 <use xlink:href="/img/icons.svg#iconNewWindow"></use>
               </svg>
             </a>
@@ -321,10 +321,10 @@
     <!-- ANCHOR main -->
     <main class="flex-grow">
       <!-- SECTION hero -->
-      <div class="border-b border-b-slate-400 bg-red-800">
+      <div class="border-b border-b-slate-800 bg-slate-950">
         <div
           id="hero"
-          class="container-full justify-stat relative flex flex-col items-center bg-gradient-to-b from-black/90 px-4 pb-20 pt-8"
+          class="container-full justify-stat relative flex flex-col items-center bg-gradient-to-b from-slate-950 via-cyan-950 to-cyan-900 px-4 pb-20 pt-8"
         >
           <!-- sm:pb-16 -->
           <!-- <div
@@ -346,7 +346,7 @@
             The McKimmon Conference and <span class="whitespace-nowrap">Training Center at NC State</span>
           </p>
           <p class="mb-8 max-w-2xl text-center text-xl font-medium text-slate-100 sm:w-3/4">
-            A community-driven framework for building events for and by cybersecurity community members.
+            Raleigh-Durham's grassroots security conference, built by and for the region's cybersecurity community.
           </p>
           <!-- <h2 class="relative mb-6 w-full text-center text-4xl font-bold text-red-50">
             <span class="italic line-through">Tickets are still available!</span>
@@ -360,10 +360,10 @@
           <p class="relative">
             <a
               href="https://www.eventzilla.net/e/bsidesrdu-2026-2138673041"
-              class="mb-6 flex flex-row items-center justify-center gap-3 rounded-3xl bg-gradient-to-b from-green-600 to-green-300 px-6 py-2 text-3xl font-semibold italic hover:from-green-500 hover:to-green-200"
+              class="mb-6 flex flex-row items-center justify-center gap-3 rounded-3xl bg-cyan-400 px-6 py-2 text-3xl font-semibold italic text-slate-950 shadow-lg shadow-cyan-500/30 transition-colors hover:bg-cyan-300"
             >
               Register or Donate Now
-              <svg class="h-7 w-7 fill-slate-800">
+              <svg class="h-7 w-7 fill-slate-950">
                 <use xlink:href="/img/icons.svg#iconNewWindow"></use>
               </svg>
             </a>
@@ -979,7 +979,7 @@
     <!-- ANCHOR: footer -->
     <footer class="flex h-20 flex-shrink flex-row items-center justify-center bg-gray-950">
       <div
-        class="flex h-20 w-full flex-row items-center justify-center bg-gradient-to-b from-red-700/70 to-red-950/70 text-sm text-slate-200"
+        class="flex h-20 w-full flex-row items-center justify-center bg-gradient-to-b from-cyan-800/70 to-cyan-950/70 text-sm text-slate-200"
       >
         <p>Copyright &copy; BSides RDU - All rights reserved</p>
       </div>


### PR DESCRIPTION
Refresh the top of the page per BSides RDU president's request — the green/red scheme read as dated/faded.

## Changes
- **Palette:** cyan CTAs on dark charcoal; green gradients removed
- **Hero background:** slate → cyan gradient (subtle cool glow under the CTA)
- **Footer:** red gradient → cyan to match
- **Hero tagline:** now RDU-specific — "Raleigh-Durham's grassroots security conference, built by and for the region's cybersecurity community" (was generic BSides boilerplate)
- **SEO:** meta description + og:description aligned with the new tagline

Scope limited to header, hero, footer, and metadata in `docs/index.html` (+ recompiled `docs/css/style.css`).